### PR TITLE
fix: adapt to new appimage filename for neovim v0.10.4

### DIFF
--- a/install_neovim.sh
+++ b/install_neovim.sh
@@ -3,7 +3,7 @@ set -e
 
 NVIM_TAG="${1-stable}"
 echo "Installing Neovim $NVIM_TAG"
-curl -sL "https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim.appimage" -o nvim.appimage
+curl -sL "https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux-x86_64.appimage" -o nvim.appimage
 chmod +x nvim.appimage
 ./nvim.appimage --appimage-extract >/dev/null
 rm -f nvim.appimage


### PR DESCRIPTION
Looks like a new version of neovim stable has been released, and the appimage name has changed. This change updates the url to download the appimage from the new release.

New release announcement: https://github.com/neovim/neovim/releases

Old release: https://github.com/neovim/neovim/releases/tag/v0.10.3